### PR TITLE
Bring back unparen'd arrow functions

### DIFF
--- a/OTHER_PROPOSALS.md
+++ b/OTHER_PROPOSALS.md
@@ -7,12 +7,13 @@ The F# Pipeline is intended to solve a small, specific problem. Other proposals 
 The [lifted pipeline operator](https://github.com/isiahmeadows/lifted-pipeline-strawman) would not be blocked or adversely impacted. None of the its syntax is used by the F# pipeline. The examples in the current README would need parentheses:
 
 ```js
-const toSlug = string =>
+const toSlug = string => (
   string
-    |> (_ => _.split(" "))
-    :> (word => word.toLowerCase())
-    |> (_ => _.join("-"))
-    |> encodeURIComponent;
+    |> _ => _.split(" ")
+    :> word => word.toLowerCase()
+    |> _ => _.join("-")
+    |> encodeURIComponent
+);
 ```
 
 This would enable pipelines to dispatch based on type, using a well-known Symbol, `Symbol.lift`. Check out [the proposal](https://github.com/isiahmeadows/lifted-pipeline-strawman) for more information.
@@ -45,7 +46,7 @@ getAllPlayers()
   |> Lazy
   |> ?this.map(p => p.name)
   |> ?this.take(5)
-  |> (_ => renderLeaderboard('#my-div', _));
+  |> _ => renderLeaderboard('#my-div', _);
 ```
 
 While this was previously wrapped in an arrow function, its inclusion turns the entire chain into a flat pipeline.

--- a/OTHER_PROPOSALS.md
+++ b/OTHER_PROPOSALS.md
@@ -4,16 +4,15 @@ The F# Pipeline is intended to solve a small, specific problem. Other proposals 
 
 ## Impact on Lifted Pipeline Operator
 
-The [lifted pipeline operator](https://github.com/isiahmeadows/lifted-pipeline-strawman) would not be blocked or adversely impacted. None of the its syntax is used by the F# pipeline. The examples in the current README would need parentheses:
+The [lifted pipeline operator](https://github.com/isiahmeadows/lifted-pipeline-strawman) would not be blocked or adversely impacted. None of the its syntax is used by the F# pipeline. The examples in the current README work fine:
 
 ```js
-const toSlug = string => (
+const toSlug = string =>
   string
     |> _ => _.split(" ")
     :> word => word.toLowerCase()
     |> _ => _.join("-")
-    |> encodeURIComponent
-);
+    |> encodeURIComponent;
 ```
 
 This would enable pipelines to dispatch based on type, using a well-known Symbol, `Symbol.lift`. Check out [the proposal](https://github.com/isiahmeadows/lifted-pipeline-strawman) for more information.
@@ -31,7 +30,7 @@ const newScore = person.score
   |> boundScore(0, 100, ?);
 ```
 
-Arrow functions currently provide this capability with more syntax. If it was included, code using arrow functions would be simplified to use partial application, improving the overall syntax of the pipeline.
+Arrow functions currently provide this capability with more syntax. If it was included, code using arrow functions could be simplified to use partial application, improving the overall syntax of the pipeline.
 
 ### Usage with `this` bound partial application
 
@@ -46,7 +45,7 @@ getAllPlayers()
   |> Lazy
   |> ?this.map(p => p.name)
   |> ?this.take(5)
-  |> _ => renderLeaderboard('#my-div', _);
+  |> renderLeaderboard('#my-div', ?);
 ```
 
 While this was previously wrapped in an arrow function, its inclusion turns the entire chain into a flat pipeline.


### PR DESCRIPTION
Highlights the impact enabling this has on other usages of the
pipeline operator.

## Questions

* Does this have any impacts on `return`?
* Is it possible to avoid wrapping assignment in parens?

## Todo

* [x]  Update spec for new precedence rules.
    * Added a TODO to the README itself.